### PR TITLE
Avoid force layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "grunt-contrib-copy": "~0.7.0"
   },
   "buildDependencies": {
-      "d3": "3.4.8"
+      "d3": "3.4.8",
+      "fastdom": "0.8.6"
   }
 }

--- a/src/begin.js
+++ b/src/begin.js
@@ -8,32 +8,32 @@
 
     if (typeof exports === "object") {
         // CommonJS
-        module.exports = dimple(require('d3'));
+        module.exports = dimple(require('d3'), require('fastdom'));
     } else {
         if (typeof define === "function" && define.amd) {
             // RequireJS | AMD
-            define(["d3"], function (d3) {
+            define(["d3", "fastdom"], function (d3, fastdom) {
                 // publish dimple to the global namespace for backwards compatibility
                 // and define it as an AMD module
-                context.dimple = dimple(d3);
+                context.dimple = dimple(d3, fastdom);
                 return context.dimple;
             });
         } else {
             // No AMD, expect d3 to exist in the current context and publish
             // dimple to the global namespace
-            if (!context.d3) {
+            if (!context.d3 || !context.fastdom) {
                 if (console && console.warn) {
-                    console.warn("dimple requires d3 to run.  Are you missing a reference to the d3 library?");
+                    console.warn("dimple requires d3 and fastdom to run.  Are you missing a reference to the d3 or fastdom library?");
                 } else {
-                    throw "dimple requires d3 to run.  Are you missing a reference to the d3 library?";
+                    throw "dimple requires d3 and fastdomr to run.  Are you missing a reference to the d3 or fastdom library?";
                 }
             } else {
-                context.dimple = dimple(context.d3);
+                context.dimple = dimple(context.d3, context.fastdom);
             }
         }
     }
 
-}(this, function (d3) {
+}(this, function (d3, fastdom) {
     "use strict";
 
     // Create the stub object

--- a/src/methods/_drawMarkerBacks.js
+++ b/src/methods/_drawMarkerBacks.js
@@ -12,52 +12,57 @@
             } else {
                 markerBacks = series._markerBacks[lineDataRow.keyString].data(lineDataRow.markerData, function (d) { return d.key; });
             }
-
-            // Add
-            if (lineShape.nextSibling && lineShape.nextSibling.id) {
-                shapes = markerBacks.enter().insert("circle", '#' + lineShape.nextSibling.id);
-            } else {
-                shapes = markerBacks.enter().append("circle");
-            }
-            shapes
-                .attr("id", function (d) { return dimple._createClass([d.key + " Marker Back"]); })
-                .attr("class", function (d) {
-                    var fields = [];
-                    if (series.x._hasCategories()) {
-                        fields = fields.concat(d.xField);
-                    }
-                    if (series.y._hasCategories()) {
-                        fields = fields.concat(d.yField);
-                    }
-                    return dimple._createClass(fields) + " " + markerBackClasses.join(" ");
-                })
-                .attr("cx", function (d) { return (series.x._hasCategories() ? dimple._helpers.cx(d, chart, series) : series.x._previousOrigin); })
-                .attr("cy", function (d) { return (series.y._hasCategories() ? dimple._helpers.cy(d, chart, series) : series.y._previousOrigin); })
-                .attr("r", 0)
-                .attr("fill", "white")
-                .attr("stroke", "none");
-
-            // Update
-            chart._handleTransition(markerBacks, duration, chart)
-                .attr("cx", function (d) { return dimple._helpers.cx(d, chart, series); })
-                .attr("cy", function (d) { return dimple._helpers.cy(d, chart, series); })
-                .attr("r", 2 + series.lineWeight);
-
-            // Remove
-            rem = chart._handleTransition(markerBacks.exit(), duration, chart)
-                .attr("cx", function (d) { return (series.x._hasCategories() ? dimple._helpers.cx(d, chart, series) : series.x._origin); })
-                .attr("cy", function (d) { return (series.y._hasCategories() ? dimple._helpers.cy(d, chart, series) : series.y._origin); })
-                .attr("r", 0);
-
-            // Run after transition methods
-            if (duration === 0) {
-                rem.remove();
-            } else {
-                rem.each("end", function () {
-                    d3.select(this).remove();
+            fastdom.read(function() {
+                shapes.each(function(d) {
+                    dimple._helpers.buildCache(d, chart, series);
                 });
-            }
+            });
+            fastdom.write(function() {
+                // Add
+                if (lineShape.nextSibling && lineShape.nextSibling.id) {
+                    shapes = markerBacks.enter().insert("circle", '#' + lineShape.nextSibling.id);
+                } else {
+                    shapes = markerBacks.enter().append("circle");
+                }
+                shapes
+                    .attr("id", function (d) { return dimple._createClass([d.key + " Marker Back"]); })
+                    .attr("class", function (d) {
+                        var fields = [];
+                        if (series.x._hasCategories()) {
+                            fields = fields.concat(d.xField);
+                        }
+                        if (series.y._hasCategories()) {
+                            fields = fields.concat(d.yField);
+                        }
+                        return dimple._createClass(fields) + " " + markerBackClasses.join(" ");
+                    })
+                    .attr("cx", function (d) { return (series.x._hasCategories() ? dimple._helpers.cx(d, chart, series) : series.x._previousOrigin); })
+                    .attr("cy", function (d) { return (series.y._hasCategories() ? dimple._helpers.cy(d, chart, series) : series.y._previousOrigin); })
+                    .attr("r", 0)
+                    .attr("fill", "white")
+                    .attr("stroke", "none");
 
+                // Update
+                chart._handleTransition(markerBacks, duration, chart)
+                    .attr("cx", function (d) { return dimple._helpers.cx(d, chart, series); })
+                    .attr("cy", function (d) { return dimple._helpers.cy(d, chart, series); })
+                    .attr("r", 2 + series.lineWeight);
+
+                // Remove
+                rem = chart._handleTransition(markerBacks.exit(), duration, chart)
+                    .attr("cx", function (d) { return (series.x._hasCategories() ? dimple._helpers.cx(d, chart, series) : series.x._origin); })
+                    .attr("cy", function (d) { return (series.y._hasCategories() ? dimple._helpers.cy(d, chart, series) : series.y._origin); })
+                    .attr("r", 0);
+
+                // Run after transition methods
+                if (duration === 0) {
+                    rem.remove();
+                } else {
+                    rem.each("end", function () {
+                        d3.select(this).remove();
+                    });
+                }
+            });
             if (series._markerBacks === undefined || series._markerBacks === null) {
                 series._markerBacks = {};
             }

--- a/src/methods/_drawMarkers.js
+++ b/src/methods/_drawMarkers.js
@@ -15,81 +15,91 @@
                 return d.key;
             });
         }
-        // Add
-        if (lineShape.nextSibling && lineShape.nextSibling.id) {
-            shapes = markers.enter().insert("circle", '#' + lineShape.nextSibling.id);
-        } else {
-            shapes = markers.enter().append("circle");
-        }
-        shapes
-            .attr("id", function (d) {
-                return dimple._createClass([d.key + " Marker"]);
-            })
-            .attr("class", function (d) {
-                var fields = [],
-                    css = chart.getClass(d.aggField.length > 0 ? d.aggField[d.aggField.length - 1] : "All");
-                if (series.x._hasCategories()) {
-                    fields = fields.concat(d.xField);
-                }
-                if (series.y._hasCategories()) {
-                    fields = fields.concat(d.yField);
-                }
-                return dimple._createClass(fields) + " " + markerClasses.join(" ") + " " + chart.customClassList.lineMarker + " " + css;
-            })
-            .on("mouseover", function (e) {
-                enterEventHandler(e, this, chart, series);
-            })
-            .on("mouseleave", function (e) {
-                leaveEventHandler(e, this, chart, series);
-            })
-            .attr("cx", function (d) {
-                return (series.x._hasCategories() ? dimple._helpers.cx(d, chart, series) : series.x._previousOrigin);
-            })
-            .attr("cy", function (d) {
-                return (series.y._hasCategories() ? dimple._helpers.cy(d, chart, series) : series.y._previousOrigin);
-            })
-            .attr("r", 0)
-            .attr("opacity", (series.lineMarkers || lineDataRow.data.length < 2 ? lineDataRow.color.opacity : 0))
-            .call(function () {
-                if (!chart.noFormats) {
-                    this.attr("fill", "white")
-                        .style("stroke-width", series.lineWeight)
-                        .attr("stroke", function (d) {
-                            return (useGradient ? dimple._helpers.fill(d, chart, series) : lineDataRow.color.stroke);
-                        });
-                }
-            });
 
-        // Update
-        chart._handleTransition(markers, duration, chart)
-            .attr("cx", function (d) { return dimple._helpers.cx(d, chart, series); })
-            .attr("cy", function (d) { return dimple._helpers.cy(d, chart, series); })
-            .attr("r", 2 + series.lineWeight)
-            .attr("opacity", (series.lineMarkers || lineDataRow.data.length < 2 ? lineDataRow.color.opacity : 0))
-            .call(function () {
-                if (!chart.noFormats) {
-                    this.attr("fill", "white")
-                        .style("stroke-width", series.lineWeight)
-                        .attr("stroke", function (d) {
-                            return (useGradient ? dimple._helpers.fill(d, chart, series) : lineDataRow.color.stroke);
-                        });
-                }
-            });
+        fastdom.read(function() {
+            if (shapes !== undefined) {
+                shapes.each(function(d) {
+                    dimple._helpers.buildCache(d, chart, series);
+                });
+            }
+        });
+        fastdom.write(function() {
+            // Add
+            if (lineShape.nextSibling && lineShape.nextSibling.id) {
+                shapes = markers.enter().insert("circle", '#' + lineShape.nextSibling.id);
+            } else {
+                shapes = markers.enter().append("circle");
+            }
+            shapes
+                .attr("id", function (d) {
+                    return dimple._createClass([d.key + " Marker"]);
+                })
+                .attr("class", function (d) {
+                    var fields = [],
+                        css = chart.getClass(d.aggField.length > 0 ? d.aggField[d.aggField.length - 1] : "All");
+                    if (series.x._hasCategories()) {
+                        fields = fields.concat(d.xField);
+                    }
+                    if (series.y._hasCategories()) {
+                        fields = fields.concat(d.yField);
+                    }
+                    return dimple._createClass(fields) + " " + markerClasses.join(" ") + " " + chart.customClassList.lineMarker + " " + css;
+                })
+                .on("mouseover", function (e) {
+                    enterEventHandler(e, this, chart, series);
+                })
+                .on("mouseleave", function (e) {
+                    leaveEventHandler(e, this, chart, series);
+                })
+                .attr("cx", function (d) {
+                    return (series.x._hasCategories() ? dimple._helpers.cx(d, chart, series) : series.x._previousOrigin);
+                })
+                .attr("cy", function (d) {
+                    return (series.y._hasCategories() ? dimple._helpers.cy(d, chart, series) : series.y._previousOrigin);
+                })
+                .attr("r", 0)
+                .attr("opacity", (series.lineMarkers || lineDataRow.data.length < 2 ? lineDataRow.color.opacity : 0))
+                .call(function () {
+                    if (!chart.noFormats) {
+                        this.attr("fill", "white")
+                            .style("stroke-width", series.lineWeight)
+                            .attr("stroke", function (d) {
+                                return (useGradient ? dimple._helpers.fill(d, chart, series) : lineDataRow.color.stroke);
+                            });
+                    }
+                });
 
-        // Remove
-        rem = chart._handleTransition(markers.exit(), duration, chart)
-            .attr("cx", function (d) { return (series.x._hasCategories() ? dimple._helpers.cx(d, chart, series) : series.x._origin); })
-            .attr("cy", function (d) { return (series.y._hasCategories() ? dimple._helpers.cy(d, chart, series) : series.y._origin); })
-            .attr("r", 0);
+            // Update
+            chart._handleTransition(markers, duration, chart)
+                .attr("cx", function (d) { return dimple._helpers.cx(d, chart, series); })
+                .attr("cy", function (d) { return dimple._helpers.cy(d, chart, series); })
+                .attr("r", 2 + series.lineWeight)
+                .attr("opacity", (series.lineMarkers || lineDataRow.data.length < 2 ? lineDataRow.color.opacity : 0))
+                .call(function () {
+                    if (!chart.noFormats) {
+                        this.attr("fill", "white")
+                            .style("stroke-width", series.lineWeight)
+                            .attr("stroke", function (d) {
+                                return (useGradient ? dimple._helpers.fill(d, chart, series) : lineDataRow.color.stroke);
+                            });
+                    }
+                });
 
-        // Run after transition methods
-        if (duration === 0) {
-            rem.remove();
-        } else {
-            rem.each("end", function () {
-                d3.select(this).remove();
-            });
-        }
+            // Remove
+            rem = chart._handleTransition(markers.exit(), duration, chart)
+                .attr("cx", function (d) { return (series.x._hasCategories() ? dimple._helpers.cx(d, chart, series) : series.x._origin); })
+                .attr("cy", function (d) { return (series.y._hasCategories() ? dimple._helpers.cy(d, chart, series) : series.y._origin); })
+                .attr("r", 0);
+
+            // Run after transition methods
+            if (duration === 0) {
+                rem.remove();
+            } else {
+                rem.each("end", function () {
+                    d3.select(this).remove();
+                });
+            }
+        });
 
         if (series._markers === undefined || series._markers === null) {
             series._markers = {};

--- a/src/methods/_helpers.js
+++ b/src/methods/_helpers.js
@@ -19,11 +19,31 @@
             stroke: []
         },
         buildCache: function(d, chart, series) {
-            fastdom.defer(1, function() { dimple._helpers.cacheHeight(d, chart, series); });
-            fastdom.defer(2, function() { dimple._helpers.cacheY(d, chart, series); });
+            fastdom.defer(1, function() {
+                dimple._helpers.cacheFill(d, chart, series);
+                dimple._helpers.cacheStroke(d, chart, series);
+                dimple._helpers.cacheOpacity(d, chart, series);
+                dimple._helpers.cacheR(d, chart, series);
+                dimple._helpers.cacheXGap(d, chart, series);
+                dimple._helpers.cacheYGap(d, chart, series);
+            });
+            fastdom.defer(2, function() {
+                dimple._helpers.cacheCx(d, chart, series);
+                dimple._helpers.cacheCy(d, chart, series);
+                dimple._helpers.cacheXClusterGap(d, chart, series);
+                dimple._helpers.cacheYClusterGap(d, chart, series);
+            });
+            fastdom.defer(3, function() {
+                dimple._helpers.cacheWidth(d, chart, series);
+                dimple._helpers.cacheHeight(d, chart, series);
+            });
+            fastdom.defer(4, function() {
+                dimple._helpers.cacheX(d, chart, series);
+                dimple._helpers.cacheY(d, chart, series);
+            });
         },
         // Calculate the centre x position
-        cx: function (d, chart, series) {
+        cacheCx: function (d, chart, series) {
             var returnCx = 0;
             if (series.x.measure !== null && series.x.measure !== undefined) {
                 returnCx = series.x._scale(d.cx);
@@ -32,11 +52,15 @@
             } else {
                 returnCx = series.x._scale(d.cx) + ((chart._widthPixels() / series.x._max) / 2);
             }
-            return returnCx;
+            dimple._helpers._cache.cx[d.key] = returnCx;
+        },
+
+        cx: function(d) {
+            return dimple._helpers._cache.cx[d.key];
         },
 
         // Calculate the centre y position
-        cy: function (d, chart, series) {
+        cacheCy: function (d, chart, series) {
             var returnCy = 0;
             if (series.y.measure !== null && series.y.measure !== undefined) {
                 returnCy = series.y._scale(d.cy);
@@ -45,11 +69,15 @@
             } else {
                 returnCy = series.y._scale(d.cy) - ((chart._heightPixels() / series.y._max) / 2);
             }
-            return returnCy;
+            dimple._helpers._cache.cy[d.key] = returnCy;
+        },
+
+        cy: function(d) {
+            return dimple._helpers._cache.cy[d.key];
         },
 
         // Calculate the radius
-        r: function (d, chart, series) {
+        cacheR: function (d, chart, series) {
             var returnR = 0,
                 scaleFactor = 1;
             if (series.z === null || series.z === undefined) {
@@ -64,47 +92,67 @@
                     returnR = series.z._scale(chart._heightPixels() / 100) * scaleFactor;
                 }
             }
-            return returnR;
+            dimple._helpers._cache.r[d.key] = returnR;
+        },
+
+        r: function(d) {
+            return dimple._helpers._cache.r[d.key];
         },
 
         // Calculate the x gap for bar type charts
-        xGap: function (chart, series) {
+        cacheXGap: function (chart, series) {
             var returnXGap = 0;
             if ((series.x.measure === null || series.x.measure === undefined) && series.barGap > 0) {
                 returnXGap = ((chart._widthPixels() / series.x._max) * (series.barGap > 0.99 ? 0.99 : series.barGap)) / 2;
             }
-            return returnXGap;
+            dimple._helpers._cache.xGap = returnXGap;
+        },
+
+        xGap: function() {
+            return dimple._helpers._cache.xGap;
         },
 
         // Calculate the x gap for clusters within bar type charts
-        xClusterGap: function (d, chart, series) {
+        cacheXClusterGap: function (d, chart, series) {
             var returnXClusterGap = 0;
             if (series.x.categoryFields !== null && series.x.categoryFields !== undefined && series.x.categoryFields.length >= 2 && series.clusterBarGap > 0 && !series.x._hasMeasure()) {
                 returnXClusterGap = (d.width * ((chart._widthPixels() / series.x._max) - (dimple._helpers.xGap(chart, series) * 2)) * (series.clusterBarGap > 0.99 ? 0.99 : series.clusterBarGap)) / 2;
             }
-            return returnXClusterGap;
+            dimple._helpers._cache.xClusterGap[d.key] = returnXClusterGap;
+        },
+
+        xClusterGap: function(d) {
+            return dimple._helpers._cache.xClusterGap[d.key];
         },
 
         // Calculate the y gap for bar type charts
-        yGap: function (chart, series) {
+        cacheYGap: function (chart, series) {
             var returnYGap = 0;
             if ((series.y.measure === null || series.y.measure === undefined) && series.barGap > 0) {
                 returnYGap = ((chart._heightPixels() / series.y._max) * (series.barGap > 0.99 ? 0.99 : series.barGap)) / 2;
             }
-            return returnYGap;
+            dimple._helpers._cache.yGap = returnYGap;
+        },
+
+        yGap: function() {
+            return dimple._helpers._cache.yGap;
         },
 
         // Calculate the y gap for clusters within bar type charts
-        yClusterGap: function (d, chart, series) {
+        cacheYClusterGap: function (d, chart, series) {
             var returnYClusterGap = 0;
             if (series.y.categoryFields !== null && series.y.categoryFields !== undefined && series.y.categoryFields.length >= 2 && series.clusterBarGap > 0 && !series.y._hasMeasure()) {
                 returnYClusterGap = (d.height * ((chart._heightPixels() / series.y._max) - (dimple._helpers.yGap(chart, series) * 2)) * (series.clusterBarGap > 0.99 ? 0.99 : series.clusterBarGap)) / 2;
             }
-            return returnYClusterGap;
+            dimple._helpers._cache.yClusterGap[d.key] = returnYClusterGap;
+        },
+
+        yClusterGap: function(d) {
+            return dimple._helpers._cache.yClusterGap[d.key];
         },
 
         // Calculate the top left x position for bar type charts
-        x: function (d, chart, series) {
+        cacheX: function (d, chart, series) {
             var returnX = 0;
             if (series.x._hasTimeField()) {
                 returnX = series.x._scale(d.x) - (dimple._helpers.width(d, chart, series) / 2);
@@ -113,7 +161,11 @@
             } else {
                 returnX = series.x._scale(d.x) + dimple._helpers.xGap(chart, series) + (d.xOffset * (dimple._helpers.width(d, chart, series) + 2 * dimple._helpers.xClusterGap(d, chart, series))) + dimple._helpers.xClusterGap(d, chart, series);
             }
-            return returnX;
+            dimple._helpers._cache.x[d.key] = returnX;
+        },
+
+        x: function(d) {
+            return dimple._helpers._cache.x[d.key];
         },
 
         // Calculate the top left y position for bar type charts
@@ -127,7 +179,6 @@
                 returnY = (series.y._scale(d.y) - (chart._heightPixels() / series.y._max)) + dimple._helpers.yGap(chart, series) + (d.yOffset * (dimple._helpers.height(d, chart, series) + 2 * dimple._helpers.yClusterGap(d, chart, series))) + dimple._helpers.yClusterGap(d, chart, series);
             }
             dimple._helpers._cache.y[d.key] = returnY;
-            console.log(d.key + " -- " + returnY);
         },
 
         y: function(d) {
@@ -135,7 +186,7 @@
         },
 
         // Calculate the width for bar type charts
-        width: function (d, chart, series) {
+        cacheWidth: function (d, chart, series) {
             var returnWidth = 0;
             if (series.x.measure !== null && series.x.measure !== undefined) {
                 returnWidth = Math.abs(series.x._scale((d.x < 0 ? d.x - d.width : d.x + d.width)) - series.x._scale(d.x));
@@ -144,7 +195,11 @@
             } else {
                 returnWidth = d.width * ((chart._widthPixels() / series.x._max) - (dimple._helpers.xGap(chart, series) * 2)) - (dimple._helpers.xClusterGap(d, chart, series) * 2);
             }
-            return returnWidth;
+            dimple._helpers._cache.width[d.key] = returnWidth;
+        },
+
+        width: function(d) {
+            return dimple._helpers._cache.width[d.key];
         },
 
         // Calculate the height for bar type charts
@@ -165,36 +220,48 @@
         },
 
         // Calculate the opacity for series
-        opacity: function (d, chart, series) {
+        cacheOpacity: function (d, chart, series) {
             var returnOpacity = 0;
             if (series.c !== null && series.c !== undefined) {
                 returnOpacity = d.opacity;
             } else {
                 returnOpacity = chart.getColor(d.aggField.slice(-1)[0]).opacity;
             }
-            return returnOpacity;
+            dimple._helpers._cache.opacity[d.key] = returnOpacity;
+        },
+
+        opacity: function(d) {
+            return dimple._helpers._cache.opacity[d.key];
         },
 
         // Calculate the fill coloring for series
-        fill: function (d, chart, series) {
+        cacheFill: function (d, chart, series) {
             var returnFill = 0;
             if (series.c !== null && series.c !== undefined) {
                 returnFill = d.fill;
             } else {
                 returnFill = chart.getColor(d.aggField.slice(-1)[0]).fill;
             }
-            return returnFill;
+            dimple._helpers._cache.fill[d.key] = returnFill;
+        },
+
+        fill: function(d) {
+            return dimple._helpers._cache.fill[d.key];
         },
 
         // Calculate the stroke coloring for series
-        stroke: function (d, chart, series) {
+        cacheStroke: function (d, chart, series) {
             var stroke = 0;
             if (series.c !== null && series.c !== undefined) {
                 stroke = d.stroke;
             } else {
                 stroke = chart.getColor(d.aggField.slice(-1)[0]).stroke;
             }
-            return stroke;
+            dimple._helpers._cache.stroke[d.key] = stroke;
+        },
+
+        stroke: function(d) {
+            return dimple._helpers._cache.stroke[d.key];
         },
 
         // Calculate the class for the series

--- a/src/methods/_helpers.js
+++ b/src/methods/_helpers.js
@@ -2,7 +2,8 @@
     // License: "https://github.com/PMSI-AlignAlytics/dimple/blob/master/MIT-LICENSE.txt"
     // Source: /src/methods/_helpers.js
     dimple._helpers = {
-
+        yCache: [],
+        heightCache: [],
         // Calculate the centre x position
         cx: function (d, chart, series) {
             var returnCx = 0;
@@ -98,16 +99,23 @@
         },
 
         // Calculate the top left y position for bar type charts
-        y: function (d, chart, series) {
-            var returnY = 0;
-            if (series.y._hasTimeField()) {
-                returnY = series.y._scale(d.y) - (dimple._helpers.height(d, chart, series) / 2);
-            } else if (series.y.measure !== null && series.y.measure !== undefined) {
-                returnY = series.y._scale(d.y);
-            } else {
-                returnY = (series.y._scale(d.y) - (chart._heightPixels() / series.y._max)) + dimple._helpers.yGap(chart, series) + (d.yOffset * (dimple._helpers.height(d, chart, series) + 2 * dimple._helpers.yClusterGap(d, chart, series))) + dimple._helpers.yClusterGap(d, chart, series);
-            }
-            return returnY;
+        by: function (d, chart, series) {
+            fastdom.defer(function() {
+                var returnY = 0;
+                if (series.y._hasTimeField()) {
+                    returnY = series.y._scale(d.y) - (dimple._helpers.height(d, chart, series) / 2);
+                } else if (series.y.measure !== null && series.y.measure !== undefined) {
+                    returnY = series.y._scale(d.y);
+                } else {
+                    returnY = (series.y._scale(d.y) - (chart._heightPixels() / series.y._max)) + dimple._helpers.yGap(chart, series) + (d.yOffset * (dimple._helpers.height(d, chart, series) + 2 * dimple._helpers.yClusterGap(d, chart, series))) + dimple._helpers.yClusterGap(d, chart, series);
+                }
+                dimple._helpers.yCache[d.key] = returnY;
+                console.log(d.key + " -- " + returnY);
+            });
+        },
+
+        y: function(d) {
+            return dimple._helpers.yCache[d.key];
         },
 
         // Calculate the width for bar type charts
@@ -124,16 +132,22 @@
         },
 
         // Calculate the height for bar type charts
-        height: function (d, chart, series) {
-            var returnHeight = 0;
-            if (series.y._hasTimeField()) {
-                returnHeight = series.y.floatingBarWidth;
-            } else if (series.y.measure !== null && series.y.measure !== undefined) {
-                returnHeight = Math.abs(series.y._scale(d.y) - series.y._scale((d.y <= 0 ? d.y + d.height : d.y - d.height)));
-            } else {
-                returnHeight = d.height * ((chart._heightPixels() / series.y._max) - (dimple._helpers.yGap(chart, series) * 2)) - (dimple._helpers.yClusterGap(d, chart, series) * 2);
-            }
-            return returnHeight;
+        bheight: function (d, chart, series) {
+            fastdom.read(function() {
+                var returnHeight = 0;
+                if (series.y._hasTimeField()) {
+                    returnHeight = series.y.floatingBarWidth;
+                } else if (series.y.measure !== null && series.y.measure !== undefined) {
+                    returnHeight = Math.abs(series.y._scale(d.y) - series.y._scale((d.y <= 0 ? d.y + d.height : d.y - d.height)));
+                } else {
+                    returnHeight = d.height * ((chart._heightPixels() / series.y._max) - (dimple._helpers.yGap(chart, series) * 2)) - (dimple._helpers.yClusterGap(d, chart, series) * 2);
+                }
+                dimple._helpers.heightCache[d.key] = returnHeight;
+            });
+        },
+
+        height: function (d) {
+            return dimple._helpers.heightCache[d.key];
         },
 
         // Calculate the opacity for series

--- a/src/methods/_helpers.js
+++ b/src/methods/_helpers.js
@@ -2,8 +2,26 @@
     // License: "https://github.com/PMSI-AlignAlytics/dimple/blob/master/MIT-LICENSE.txt"
     // Source: /src/methods/_helpers.js
     dimple._helpers = {
-        yCache: [],
-        heightCache: [],
+        _cache: {
+            cx: [],
+            cy: [],
+            r: [],
+            xGap: [],
+            xClusterGap: [],
+            yGap: [],
+            yClusterGap: [],
+            x: [],
+            y: [],
+            width: [],
+            height: [],
+            opacity: [],
+            fill: [],
+            stroke: []
+        },
+        buildCache: function(d, chart, series) {
+            fastdom.defer(1, function() { dimple._helpers.cacheHeight(d, chart, series); });
+            fastdom.defer(2, function() { dimple._helpers.cacheY(d, chart, series); });
+        },
         // Calculate the centre x position
         cx: function (d, chart, series) {
             var returnCx = 0;
@@ -99,23 +117,21 @@
         },
 
         // Calculate the top left y position for bar type charts
-        by: function (d, chart, series) {
-            fastdom.defer(function() {
-                var returnY = 0;
-                if (series.y._hasTimeField()) {
-                    returnY = series.y._scale(d.y) - (dimple._helpers.height(d, chart, series) / 2);
-                } else if (series.y.measure !== null && series.y.measure !== undefined) {
-                    returnY = series.y._scale(d.y);
-                } else {
-                    returnY = (series.y._scale(d.y) - (chart._heightPixels() / series.y._max)) + dimple._helpers.yGap(chart, series) + (d.yOffset * (dimple._helpers.height(d, chart, series) + 2 * dimple._helpers.yClusterGap(d, chart, series))) + dimple._helpers.yClusterGap(d, chart, series);
-                }
-                dimple._helpers.yCache[d.key] = returnY;
-                console.log(d.key + " -- " + returnY);
-            });
+        cacheY: function (d, chart, series) {
+            var returnY = 0;
+            if (series.y._hasTimeField()) {
+                returnY = series.y._scale(d.y) - (dimple._helpers.height(d, chart, series) / 2);
+            } else if (series.y.measure !== null && series.y.measure !== undefined) {
+                returnY = series.y._scale(d.y);
+            } else {
+                returnY = (series.y._scale(d.y) - (chart._heightPixels() / series.y._max)) + dimple._helpers.yGap(chart, series) + (d.yOffset * (dimple._helpers.height(d, chart, series) + 2 * dimple._helpers.yClusterGap(d, chart, series))) + dimple._helpers.yClusterGap(d, chart, series);
+            }
+            dimple._helpers._cache.y[d.key] = returnY;
+            console.log(d.key + " -- " + returnY);
         },
 
         y: function(d) {
-            return dimple._helpers.yCache[d.key];
+            return dimple._helpers._cache.y[d.key];
         },
 
         // Calculate the width for bar type charts
@@ -132,22 +148,20 @@
         },
 
         // Calculate the height for bar type charts
-        bheight: function (d, chart, series) {
-            fastdom.read(function() {
-                var returnHeight = 0;
-                if (series.y._hasTimeField()) {
-                    returnHeight = series.y.floatingBarWidth;
-                } else if (series.y.measure !== null && series.y.measure !== undefined) {
-                    returnHeight = Math.abs(series.y._scale(d.y) - series.y._scale((d.y <= 0 ? d.y + d.height : d.y - d.height)));
-                } else {
-                    returnHeight = d.height * ((chart._heightPixels() / series.y._max) - (dimple._helpers.yGap(chart, series) * 2)) - (dimple._helpers.yClusterGap(d, chart, series) * 2);
-                }
-                dimple._helpers.heightCache[d.key] = returnHeight;
-            });
+        cacheHeight: function (d, chart, series) {
+            var returnHeight = 0;
+            if (series.y._hasTimeField()) {
+                returnHeight = series.y.floatingBarWidth;
+            } else if (series.y.measure !== null && series.y.measure !== undefined) {
+                returnHeight = Math.abs(series.y._scale(d.y) - series.y._scale((d.y <= 0 ? d.y + d.height : d.y - d.height)));
+            } else {
+                returnHeight = d.height * ((chart._heightPixels() / series.y._max) - (dimple._helpers.yGap(chart, series) * 2)) - (dimple._helpers.yClusterGap(d, chart, series) * 2);
+            }
+            dimple._helpers._cache.height[d.key] = returnHeight;
         },
 
         height: function (d) {
-            return dimple._helpers.heightCache[d.key];
+            return dimple._helpers._cache.height[d.key];
         },
 
         // Calculate the opacity for series

--- a/src/methods/_helpers.js
+++ b/src/methods/_helpers.js
@@ -24,8 +24,8 @@
                 dimple._helpers.cacheStroke(d, chart, series);
                 dimple._helpers.cacheOpacity(d, chart, series);
                 dimple._helpers.cacheR(d, chart, series);
-                dimple._helpers.cacheXGap(d, chart, series);
-                dimple._helpers.cacheYGap(d, chart, series);
+                dimple._helpers.cacheXGap(chart, series);
+                dimple._helpers.cacheYGap(chart, series);
             });
             fastdom.defer(2, function() {
                 dimple._helpers.cacheCx(d, chart, series);

--- a/src/methods/_helpers.js
+++ b/src/methods/_helpers.js
@@ -9,16 +9,20 @@
                 dimple._helpers.cacheStroke(d, chart, series);
                 dimple._helpers.cacheOpacity(d, chart, series);
                 dimple._helpers.cacheR(d, chart, series);
-                dimple._helpers.cacheXGap(chart, series);
-                dimple._helpers.cacheYGap(chart, series);
-                dimple._helpers.cacheCx(d, chart, series);
-                dimple._helpers.cacheCy(d, chart, series);
-                dimple._helpers.cacheXClusterGap(d, chart, series);
-                dimple._helpers.cacheYClusterGap(d, chart, series);
-                dimple._helpers.cacheWidth(d, chart, series);
-                dimple._helpers.cacheHeight(d, chart, series);
-                dimple._helpers.cacheX(d, chart, series);
-                dimple._helpers.cacheY(d, chart, series);
+                if (series.x) {
+                    dimple._helpers.cacheXGap(chart, series);
+                    dimple._helpers.cacheCx(d, chart, series);
+                    dimple._helpers.cacheXClusterGap(d, chart, series);
+                    dimple._helpers.cacheWidth(d, chart, series);
+                    dimple._helpers.cacheX(d, chart, series);
+                }
+                if (series.y) {
+                    dimple._helpers.cacheYGap(chart, series);
+                    dimple._helpers.cacheCy(d, chart, series);
+                    dimple._helpers.cacheYClusterGap(d, chart, series);
+                    dimple._helpers.cacheHeight(d, chart, series);
+                    dimple._helpers.cacheY(d, chart, series);
+                }
             });
         },
         // Calculate the centre x position

--- a/src/methods/_helpers.js
+++ b/src/methods/_helpers.js
@@ -1,43 +1,22 @@
     // Copyright: 2015 AlignAlytics
     // License: "https://github.com/PMSI-AlignAlytics/dimple/blob/master/MIT-LICENSE.txt"
     // Source: /src/methods/_helpers.js
+    /*jslint unparam: true, node: true */
     dimple._helpers = {
-        _cache: {
-            cx: [],
-            cy: [],
-            r: [],
-            xGap: [],
-            xClusterGap: [],
-            yGap: [],
-            yClusterGap: [],
-            x: [],
-            y: [],
-            width: [],
-            height: [],
-            opacity: [],
-            fill: [],
-            stroke: []
-        },
         buildCache: function(d, chart, series) {
-            fastdom.defer(1, function() {
+            fastdom.read(function() {
                 dimple._helpers.cacheFill(d, chart, series);
                 dimple._helpers.cacheStroke(d, chart, series);
                 dimple._helpers.cacheOpacity(d, chart, series);
                 dimple._helpers.cacheR(d, chart, series);
                 dimple._helpers.cacheXGap(chart, series);
                 dimple._helpers.cacheYGap(chart, series);
-            });
-            fastdom.defer(2, function() {
                 dimple._helpers.cacheCx(d, chart, series);
                 dimple._helpers.cacheCy(d, chart, series);
                 dimple._helpers.cacheXClusterGap(d, chart, series);
                 dimple._helpers.cacheYClusterGap(d, chart, series);
-            });
-            fastdom.defer(3, function() {
                 dimple._helpers.cacheWidth(d, chart, series);
                 dimple._helpers.cacheHeight(d, chart, series);
-            });
-            fastdom.defer(4, function() {
                 dimple._helpers.cacheX(d, chart, series);
                 dimple._helpers.cacheY(d, chart, series);
             });
@@ -52,11 +31,11 @@
             } else {
                 returnCx = series.x._scale(d.cx) + ((chart._widthPixels() / series.x._max) / 2);
             }
-            dimple._helpers._cache.cx[d.key] = returnCx;
+            series.domCache.cx[d.key] = returnCx;
         },
 
-        cx: function(d) {
-            return dimple._helpers._cache.cx[d.key];
+        cx: function(d, chart, series) {
+            return series.domCache.cx[d.key];
         },
 
         // Calculate the centre y position
@@ -69,11 +48,11 @@
             } else {
                 returnCy = series.y._scale(d.cy) - ((chart._heightPixels() / series.y._max) / 2);
             }
-            dimple._helpers._cache.cy[d.key] = returnCy;
+            series.domCache.cy[d.key] = returnCy;
         },
 
-        cy: function(d) {
-            return dimple._helpers._cache.cy[d.key];
+        cy: function(d, chart, series) {
+            return series.domCache.cy[d.key];
         },
 
         // Calculate the radius
@@ -92,11 +71,11 @@
                     returnR = series.z._scale(chart._heightPixels() / 100) * scaleFactor;
                 }
             }
-            dimple._helpers._cache.r[d.key] = returnR;
+            series.domCache.r[d.key] = returnR;
         },
 
-        r: function(d) {
-            return dimple._helpers._cache.r[d.key];
+        r: function(d, chart, series) {
+            return series.domCache.r[d.key];
         },
 
         // Calculate the x gap for bar type charts
@@ -105,11 +84,11 @@
             if ((series.x.measure === null || series.x.measure === undefined) && series.barGap > 0) {
                 returnXGap = ((chart._widthPixels() / series.x._max) * (series.barGap > 0.99 ? 0.99 : series.barGap)) / 2;
             }
-            dimple._helpers._cache.xGap = returnXGap;
+            series.domCache.xGap = returnXGap;
         },
 
-        xGap: function() {
-            return dimple._helpers._cache.xGap;
+        xGap: function(chart, series) {
+            return series.domCache.xGap;
         },
 
         // Calculate the x gap for clusters within bar type charts
@@ -118,11 +97,11 @@
             if (series.x.categoryFields !== null && series.x.categoryFields !== undefined && series.x.categoryFields.length >= 2 && series.clusterBarGap > 0 && !series.x._hasMeasure()) {
                 returnXClusterGap = (d.width * ((chart._widthPixels() / series.x._max) - (dimple._helpers.xGap(chart, series) * 2)) * (series.clusterBarGap > 0.99 ? 0.99 : series.clusterBarGap)) / 2;
             }
-            dimple._helpers._cache.xClusterGap[d.key] = returnXClusterGap;
+            series.domCache.xClusterGap[d.key] = returnXClusterGap;
         },
 
-        xClusterGap: function(d) {
-            return dimple._helpers._cache.xClusterGap[d.key];
+        xClusterGap: function(d, chart, series) {
+            return series.domCache.xClusterGap[d.key];
         },
 
         // Calculate the y gap for bar type charts
@@ -131,11 +110,11 @@
             if ((series.y.measure === null || series.y.measure === undefined) && series.barGap > 0) {
                 returnYGap = ((chart._heightPixels() / series.y._max) * (series.barGap > 0.99 ? 0.99 : series.barGap)) / 2;
             }
-            dimple._helpers._cache.yGap = returnYGap;
+            series.domCache.yGap = returnYGap;
         },
 
-        yGap: function() {
-            return dimple._helpers._cache.yGap;
+        yGap: function(chart, series) {
+            return series.domCache.yGap;
         },
 
         // Calculate the y gap for clusters within bar type charts
@@ -144,11 +123,11 @@
             if (series.y.categoryFields !== null && series.y.categoryFields !== undefined && series.y.categoryFields.length >= 2 && series.clusterBarGap > 0 && !series.y._hasMeasure()) {
                 returnYClusterGap = (d.height * ((chart._heightPixels() / series.y._max) - (dimple._helpers.yGap(chart, series) * 2)) * (series.clusterBarGap > 0.99 ? 0.99 : series.clusterBarGap)) / 2;
             }
-            dimple._helpers._cache.yClusterGap[d.key] = returnYClusterGap;
+            series.domCache.yClusterGap[d.key] = returnYClusterGap;
         },
 
-        yClusterGap: function(d) {
-            return dimple._helpers._cache.yClusterGap[d.key];
+        yClusterGap: function(d, chart, series) {
+            return series.domCache.yClusterGap[d.key];
         },
 
         // Calculate the top left x position for bar type charts
@@ -161,11 +140,11 @@
             } else {
                 returnX = series.x._scale(d.x) + dimple._helpers.xGap(chart, series) + (d.xOffset * (dimple._helpers.width(d, chart, series) + 2 * dimple._helpers.xClusterGap(d, chart, series))) + dimple._helpers.xClusterGap(d, chart, series);
             }
-            dimple._helpers._cache.x[d.key] = returnX;
+            series.domCache.x[d.key] = returnX;
         },
 
-        x: function(d) {
-            return dimple._helpers._cache.x[d.key];
+        x: function(d, chart, series) {
+            return series.domCache.x[d.key];
         },
 
         // Calculate the top left y position for bar type charts
@@ -178,11 +157,11 @@
             } else {
                 returnY = (series.y._scale(d.y) - (chart._heightPixels() / series.y._max)) + dimple._helpers.yGap(chart, series) + (d.yOffset * (dimple._helpers.height(d, chart, series) + 2 * dimple._helpers.yClusterGap(d, chart, series))) + dimple._helpers.yClusterGap(d, chart, series);
             }
-            dimple._helpers._cache.y[d.key] = returnY;
+            series.domCache.y[d.key] = returnY;
         },
 
-        y: function(d) {
-            return dimple._helpers._cache.y[d.key];
+        y: function(d, chart, series) {
+            return series.domCache.y[d.key];
         },
 
         // Calculate the width for bar type charts
@@ -195,11 +174,11 @@
             } else {
                 returnWidth = d.width * ((chart._widthPixels() / series.x._max) - (dimple._helpers.xGap(chart, series) * 2)) - (dimple._helpers.xClusterGap(d, chart, series) * 2);
             }
-            dimple._helpers._cache.width[d.key] = returnWidth;
+            series.domCache.width[d.key] = returnWidth;
         },
 
-        width: function(d) {
-            return dimple._helpers._cache.width[d.key];
+        width: function(d, chart, series) {
+            return series.domCache.width[d.key];
         },
 
         // Calculate the height for bar type charts
@@ -212,11 +191,11 @@
             } else {
                 returnHeight = d.height * ((chart._heightPixels() / series.y._max) - (dimple._helpers.yGap(chart, series) * 2)) - (dimple._helpers.yClusterGap(d, chart, series) * 2);
             }
-            dimple._helpers._cache.height[d.key] = returnHeight;
+            series.domCache.height[d.key] = returnHeight;
         },
 
-        height: function (d) {
-            return dimple._helpers._cache.height[d.key];
+        height: function (d, chart, series) {
+            return series.domCache.height[d.key];
         },
 
         // Calculate the opacity for series
@@ -227,11 +206,11 @@
             } else {
                 returnOpacity = chart.getColor(d.aggField.slice(-1)[0]).opacity;
             }
-            dimple._helpers._cache.opacity[d.key] = returnOpacity;
+            series.domCache.opacity[d.key] = returnOpacity;
         },
 
-        opacity: function(d) {
-            return dimple._helpers._cache.opacity[d.key];
+        opacity: function(d, chart, series) {
+            return series.domCache.opacity[d.key];
         },
 
         // Calculate the fill coloring for series
@@ -242,11 +221,11 @@
             } else {
                 returnFill = chart.getColor(d.aggField.slice(-1)[0]).fill;
             }
-            dimple._helpers._cache.fill[d.key] = returnFill;
+            series.domCache.fill[d.key] = returnFill;
         },
 
-        fill: function(d) {
-            return dimple._helpers._cache.fill[d.key];
+        fill: function(d, chart, series) {
+            return series.domCache.fill[d.key];
         },
 
         // Calculate the stroke coloring for series
@@ -257,11 +236,11 @@
             } else {
                 stroke = chart.getColor(d.aggField.slice(-1)[0]).stroke;
             }
-            dimple._helpers._cache.stroke[d.key] = stroke;
+            series.domCache.stroke[d.key] = stroke;
         },
 
-        stroke: function(d) {
-            return dimple._helpers._cache.stroke[d.key];
+        stroke: function(d, chart, series) {
+            return series.domCache.stroke[d.key];
         },
 
         // Calculate the class for the series

--- a/src/objects/plot/area.js
+++ b/src/objects/plot/area.js
@@ -179,7 +179,7 @@
                     }
                 }
             });
-            fastdom.defer(5, function() {
+            fastdom.write(function() {
                 // Create a set of area data grouped by the aggregation field
                 for (i = 0; i < areaData.length; i += 1) {
                     // Sort the points so that areas are connected in the correct order
@@ -357,7 +357,7 @@
                         dimple._helpers.buildCache(d, chart, series);
                     });
             });
-            fastdom.defer(, function() {
+            fastdom.write(function() {
                 // Add
                 addShapes
                     .attr("id", function (d) { return dimple._createClass([d.key]); })

--- a/src/objects/plot/bar.js
+++ b/src/objects/plot/bar.js
@@ -44,16 +44,16 @@
             }
 
             // Add
-            addShapes = theseShapes
-                .enter()
-                .append("rect")
-                .each(function (d) {
-                    dimple._helpers.buildCache(d, chart, series);
-                });
-            fastdom.defer(3, function() {
+            fastdom.read(function() {
+                addShapes = theseShapes
+                    .enter()
+                    .append("rect")
+                    .each(function (d) {
+                        dimple._helpers.buildCache(d, chart, series);
+                    });
+            });
+            fastdom.write(function() {
                 addShapes
-                    //.enter()
-                    //.append("rect")
                     .attr("id", function (d) { return dimple._createClass([d.key]); })
                     .attr("class", function (d) {
                         var c = [];

--- a/src/objects/plot/bar.js
+++ b/src/objects/plot/bar.js
@@ -48,7 +48,6 @@
                 .enter()
                 .append("rect")
                 .each(function (d) {
-                    console.log(d.key);
                     dimple._helpers.buildCache(d, chart, series);
                 });
             fastdom.defer(3, function() {

--- a/src/objects/plot/bar.js
+++ b/src/objects/plot/bar.js
@@ -49,10 +49,9 @@
                 .append("rect")
                 .each(function (d) {
                     console.log(d.key);
-                    dimple._helpers.bheight(d, chart, series);
-                    dimple._helpers.by(d, chart, series);
+                    dimple._helpers.buildCache(d, chart, series);
                 });
-            fastdom.defer(function() {
+            fastdom.defer(3, function() {
                 addShapes
                     //.enter()
                     //.append("rect")
@@ -76,14 +75,14 @@
                     .attr("y", function (d) {
                         var returnValue = series.y._previousOrigin;
                         if (cat === "y") {
-                            returnValue = dimple._helpers.yCache[d.key];
+                            returnValue = dimple._helpers.y(d, chart, series);
                         } else if (cat === "both") {
                             returnValue = dimple._helpers.cy(d, chart, series);
                         }
                         return returnValue;
                     })
                     .attr("width", function (d) { return (cat === "x" ?  dimple._helpers.width(d, chart, series) : 0); })
-                    .attr("height", function (d) { return (cat === "y" ?  dimple._helpers.heightCache[d.key] : 0); })
+                    .attr("height", function (d) { return (cat === "y" ?  dimple._helpers.height(d, chart, series) : 0); })
                     .on("mouseover", function (e) { dimple._showBarTooltip(e, this, chart, series); })
                     .on("mouseleave", function (e) { dimple._removeTooltip(e, this, chart, series); })
                     .call(function () {
@@ -97,9 +96,9 @@
                 // Update
                 updated = chart._handleTransition(theseShapes, duration, chart, series)
                     .attr("x", function (d) { return xFloat ? dimple._helpers.cx(d, chart, series) - series.x.floatingBarWidth / 2 : dimple._helpers.x(d, chart, series); })
-                    .attr("y", function (d) { return yFloat ? dimple._helpers.cy(d, chart, series) - series.y.floatingBarWidth / 2 : dimple._helpers.yCache[d.key]; })
+                    .attr("y", function (d) { return yFloat ? dimple._helpers.cy(d, chart, series) - series.y.floatingBarWidth / 2 : dimple._helpers.y(d, chart, series); })
                     .attr("width", function (d) { return (xFloat ? series.x.floatingBarWidth : dimple._helpers.width(d, chart, series)); })
-                    .attr("height", function (d) { return (yFloat ? series.y.floatingBarWidth : dimple._helpers.heightCache[d.key]); })
+                    .attr("height", function (d) { return (yFloat ? series.y.floatingBarWidth : dimple._helpers.height(d, chart, series)); })
                     .call(function () {
                         if (!chart.noFormats) {
                             this.attr("fill", function (d) { return dimple._helpers.fill(d, chart, series); })
@@ -120,14 +119,14 @@
                     .attr("y", function (d) {
                         var returnValue = series.y._origin;
                         if (cat === "y") {
-                            returnValue = dimple._helpers.yCache[d.key];
+                            returnValue = dimple._helpers.y(d, chart, series);
                         } else if (cat === "both") {
                             returnValue = dimple._helpers.cy(d, chart, series);
                         }
                         return returnValue;
                     })
                     .attr("width", function (d) { return (cat === "x" ?  dimple._helpers.width(d, chart, series) : 0); })
-                    .attr("height", function (d) { return (cat === "y" ?  dimple._helpers.heightCache[d.key] : 0); });
+                    .attr("height", function (d) { return (cat === "y" ?  dimple._helpers.height(d, chart, series) : 0); });
                 dimple._postDrawHandling(series, updated, removed, duration);
             });
             // Save the shapes to the series array

--- a/src/objects/plot/bar.js
+++ b/src/objects/plot/bar.js
@@ -16,6 +16,7 @@
         draw: function (chart, series, duration) {
 
             var chartData = series._positionData,
+                addShapes = null,
                 theseShapes = null,
                 classes = ["dimple-series-" + chart.series.indexOf(series), "dimple-bar"],
                 updated,
@@ -43,85 +44,92 @@
             }
 
             // Add
-            theseShapes
+            addShapes = theseShapes
                 .enter()
                 .append("rect")
-                .attr("id", function (d) { return dimple._createClass([d.key]); })
-                .attr("class", function (d) {
-                    var c = [];
-                    c = c.concat(d.aggField);
-                    c = c.concat(d.xField);
-                    c = c.concat(d.yField);
-                    return classes.join(" ") + " " + dimple._createClass(c) + " " + chart.customClassList.barSeries + " " + dimple._helpers.css(d, chart);
-                })
-                .attr("x", function (d) {
-                    var returnValue = series.x._previousOrigin;
-                    if (cat === "x") {
-                        returnValue = dimple._helpers.x(d, chart, series);
-                    } else if (cat === "both") {
-                        returnValue = dimple._helpers.cx(d, chart, series);
-                    }
-                    return returnValue;
-                })
-                .attr("y", function (d) {
-                    var returnValue = series.y._previousOrigin;
-                    if (cat === "y") {
-                        returnValue = dimple._helpers.y(d, chart, series);
-                    } else if (cat === "both") {
-                        returnValue = dimple._helpers.cy(d, chart, series);
-                    }
-                    return returnValue;
-                })
-                .attr("width", function (d) { return (cat === "x" ?  dimple._helpers.width(d, chart, series) : 0); })
-                .attr("height", function (d) { return (cat === "y" ?  dimple._helpers.height(d, chart, series) : 0); })
-                .on("mouseover", function (e) { dimple._showBarTooltip(e, this, chart, series); })
-                .on("mouseleave", function (e) { dimple._removeTooltip(e, this, chart, series); })
-                .call(function () {
-                    if (!chart.noFormats) {
-                        this.attr("opacity", function (d) { return dimple._helpers.opacity(d, chart, series); })
-                            .style("fill", function (d) { return dimple._helpers.fill(d, chart, series); })
-                            .style("stroke", function (d) { return dimple._helpers.stroke(d, chart, series); });
-                    }
+                .each(function (d) {
+                    console.log(d.key);
+                    dimple._helpers.bheight(d, chart, series);
+                    dimple._helpers.by(d, chart, series);
                 });
+            fastdom.defer(function() {
+                addShapes
+                    //.enter()
+                    //.append("rect")
+                    .attr("id", function (d) { return dimple._createClass([d.key]); })
+                    .attr("class", function (d) {
+                        var c = [];
+                        c = c.concat(d.aggField);
+                        c = c.concat(d.xField);
+                        c = c.concat(d.yField);
+                        return classes.join(" ") + " " + dimple._createClass(c) + " " + chart.customClassList.barSeries + " " + dimple._helpers.css(d, chart);
+                    })
+                    .attr("x", function (d) {
+                        var returnValue = series.x._previousOrigin;
+                        if (cat === "x") {
+                            returnValue = dimple._helpers.x(d, chart, series);
+                        } else if (cat === "both") {
+                            returnValue = dimple._helpers.cx(d, chart, series);
+                        }
+                        return returnValue;
+                    })
+                    .attr("y", function (d) {
+                        var returnValue = series.y._previousOrigin;
+                        if (cat === "y") {
+                            returnValue = dimple._helpers.yCache[d.key];
+                        } else if (cat === "both") {
+                            returnValue = dimple._helpers.cy(d, chart, series);
+                        }
+                        return returnValue;
+                    })
+                    .attr("width", function (d) { return (cat === "x" ?  dimple._helpers.width(d, chart, series) : 0); })
+                    .attr("height", function (d) { return (cat === "y" ?  dimple._helpers.heightCache[d.key] : 0); })
+                    .on("mouseover", function (e) { dimple._showBarTooltip(e, this, chart, series); })
+                    .on("mouseleave", function (e) { dimple._removeTooltip(e, this, chart, series); })
+                    .call(function () {
+                        if (!chart.noFormats) {
+                            this.attr("opacity", function (d) { return dimple._helpers.opacity(d, chart, series); })
+                                .style("fill", function (d) { return dimple._helpers.fill(d, chart, series); })
+                                .style("stroke", function (d) { return dimple._helpers.stroke(d, chart, series); });
+                        }
+                    });
 
-            // Update
-            updated = chart._handleTransition(theseShapes, duration, chart, series)
-                .attr("x", function (d) { return xFloat ? dimple._helpers.cx(d, chart, series) - series.x.floatingBarWidth / 2 : dimple._helpers.x(d, chart, series); })
-                .attr("y", function (d) { return yFloat ? dimple._helpers.cy(d, chart, series) - series.y.floatingBarWidth / 2 : dimple._helpers.y(d, chart, series); })
-                .attr("width", function (d) { return (xFloat ? series.x.floatingBarWidth : dimple._helpers.width(d, chart, series)); })
-                .attr("height", function (d) { return (yFloat ? series.y.floatingBarWidth : dimple._helpers.height(d, chart, series)); })
-                .call(function () {
-                    if (!chart.noFormats) {
-                        this.attr("fill", function (d) { return dimple._helpers.fill(d, chart, series); })
-                            .attr("stroke", function (d) { return dimple._helpers.stroke(d, chart, series); });
-                    }
-                });
-
-            // Remove
-            removed = chart._handleTransition(theseShapes.exit(), duration, chart, series)
-                .attr("x", function (d) {
-                    var returnValue = series.x._origin;
-                    if (cat === "x") {
-                        returnValue = dimple._helpers.x(d, chart, series);
-                    } else if (cat === "both") {
-                        returnValue = dimple._helpers.cx(d, chart, series);
-                    }
-                    return returnValue;
-                })
-                .attr("y", function (d) {
-                    var returnValue = series.y._origin;
-                    if (cat === "y") {
-                        returnValue = dimple._helpers.y(d, chart, series);
-                    } else if (cat === "both") {
-                        returnValue = dimple._helpers.cy(d, chart, series);
-                    }
-                    return returnValue;
-                })
-                .attr("width", function (d) { return (cat === "x" ?  dimple._helpers.width(d, chart, series) : 0); })
-                .attr("height", function (d) { return (cat === "y" ?  dimple._helpers.height(d, chart, series) : 0); });
-
-            dimple._postDrawHandling(series, updated, removed, duration);
-
+                // Update
+                updated = chart._handleTransition(theseShapes, duration, chart, series)
+                    .attr("x", function (d) { return xFloat ? dimple._helpers.cx(d, chart, series) - series.x.floatingBarWidth / 2 : dimple._helpers.x(d, chart, series); })
+                    .attr("y", function (d) { return yFloat ? dimple._helpers.cy(d, chart, series) - series.y.floatingBarWidth / 2 : dimple._helpers.yCache[d.key]; })
+                    .attr("width", function (d) { return (xFloat ? series.x.floatingBarWidth : dimple._helpers.width(d, chart, series)); })
+                    .attr("height", function (d) { return (yFloat ? series.y.floatingBarWidth : dimple._helpers.heightCache[d.key]); })
+                    .call(function () {
+                        if (!chart.noFormats) {
+                            this.attr("fill", function (d) { return dimple._helpers.fill(d, chart, series); })
+                                .attr("stroke", function (d) { return dimple._helpers.stroke(d, chart, series); });
+                        }
+                    });
+                // Remove
+                removed = chart._handleTransition(theseShapes.exit(), duration, chart, series)
+                    .attr("x", function (d) {
+                        var returnValue = series.x._origin;
+                        if (cat === "x") {
+                            returnValue = dimple._helpers.x(d, chart, series);
+                        } else if (cat === "both") {
+                            returnValue = dimple._helpers.cx(d, chart, series);
+                        }
+                        return returnValue;
+                    })
+                    .attr("y", function (d) {
+                        var returnValue = series.y._origin;
+                        if (cat === "y") {
+                            returnValue = dimple._helpers.yCache[d.key];
+                        } else if (cat === "both") {
+                            returnValue = dimple._helpers.cy(d, chart, series);
+                        }
+                        return returnValue;
+                    })
+                    .attr("width", function (d) { return (cat === "x" ?  dimple._helpers.width(d, chart, series) : 0); })
+                    .attr("height", function (d) { return (cat === "y" ?  dimple._helpers.heightCache[d.key] : 0); });
+                dimple._postDrawHandling(series, updated, removed, duration);
+            });
             // Save the shapes to the series array
             series.shapes = theseShapes;
         }

--- a/src/objects/plot/bubble.js
+++ b/src/objects/plot/bubble.js
@@ -16,6 +16,7 @@
         draw: function (chart, series, duration) {
 
             var chartData = series._positionData,
+                addShapes = null,
                 theseShapes = null,
                 classes = ["dimple-series-" + chart.series.indexOf(series), "dimple-bubble"],
                 updated,
@@ -32,53 +33,59 @@
                     return d.key;
                 });
             }
+            fastdom.read(function() {
+                addShapes = theseShapes
+                    .enter()
+                    .append("circle")
+                    .each(function(d) {
+                        dimple._helpers.buildCache(d, chart, series);
+                    });
+            });
+            fastdom.write(function() {
+                // Ads
+                addShapes
+                    .attr("id", function (d) { return dimple._createClass([d.key]); })
+                    .attr("class", function (d) {
+                        var c = [];
+                        c = c.concat(d.aggField);
+                        c = c.concat(d.xField);
+                        c = c.concat(d.yField);
+                        c = c.concat(d.zField);
+                        return classes.join(" ") + " " + dimple._createClass(c) + " " + chart.customClassList.bubbleSeries + " " + dimple._helpers.css(d, chart);
+                    })
+                    .attr("cx", function (d) { return (series.x._hasCategories() ? dimple._helpers.cx(d, chart, series) : series.x._previousOrigin); })
+                    .attr("cy", function (d) { return (series.y._hasCategories() ? dimple._helpers.cy(d, chart, series) : series.y._previousOrigin); })
+                    .attr("r", 0)
+                    .on("mouseover", function (e) { dimple._showPointTooltip(e, this, chart, series); })
+                    .on("mouseleave", function (e) { dimple._removeTooltip(e, this, chart, series); })
+                    .call(function () {
+                        if (!chart.noFormats) {
+                            this.attr("opacity", function (d) { return dimple._helpers.opacity(d, chart, series); })
+                                .style("fill", function (d) { return dimple._helpers.fill(d, chart, series); })
+                                .style("stroke", function (d) { return dimple._helpers.stroke(d, chart, series); });
+                        }
+                    });
 
-            // Add
-            theseShapes
-                .enter()
-                .append("circle")
-                .attr("id", function (d) { return dimple._createClass([d.key]); })
-                .attr("class", function (d) {
-                    var c = [];
-                    c = c.concat(d.aggField);
-                    c = c.concat(d.xField);
-                    c = c.concat(d.yField);
-                    c = c.concat(d.zField);
-                    return classes.join(" ") + " " + dimple._createClass(c) + " " + chart.customClassList.bubbleSeries + " " + dimple._helpers.css(d, chart);
-                })
-                .attr("cx", function (d) { return (series.x._hasCategories() ? dimple._helpers.cx(d, chart, series) : series.x._previousOrigin); })
-                .attr("cy", function (d) { return (series.y._hasCategories() ? dimple._helpers.cy(d, chart, series) : series.y._previousOrigin); })
-                .attr("r", 0)
-                .on("mouseover", function (e) { dimple._showPointTooltip(e, this, chart, series); })
-                .on("mouseleave", function (e) { dimple._removeTooltip(e, this, chart, series); })
-                .call(function () {
-                    if (!chart.noFormats) {
-                        this.attr("opacity", function (d) { return dimple._helpers.opacity(d, chart, series); })
-                            .style("fill", function (d) { return dimple._helpers.fill(d, chart, series); })
-                            .style("stroke", function (d) { return dimple._helpers.stroke(d, chart, series); });
-                    }
-                });
+                // Update
+                updated = chart._handleTransition(theseShapes, duration, chart, series)
+                    .attr("cx", function (d) { return dimple._helpers.cx(d, chart, series); })
+                    .attr("cy", function (d) { return dimple._helpers.cy(d, chart, series); })
+                    .attr("r", function (d) { return dimple._helpers.r(d, chart, series); })
+                    .call(function () {
+                        if (!chart.noFormats) {
+                            this.attr("fill", function (d) { return dimple._helpers.fill(d, chart, series); })
+                                .attr("stroke", function (d) { return dimple._helpers.stroke(d, chart, series); });
+                        }
+                    });
 
-            // Update
-            updated = chart._handleTransition(theseShapes, duration, chart, series)
-                .attr("cx", function (d) { return dimple._helpers.cx(d, chart, series); })
-                .attr("cy", function (d) { return dimple._helpers.cy(d, chart, series); })
-                .attr("r", function (d) { return dimple._helpers.r(d, chart, series); })
-                .call(function () {
-                    if (!chart.noFormats) {
-                        this.attr("fill", function (d) { return dimple._helpers.fill(d, chart, series); })
-                            .attr("stroke", function (d) { return dimple._helpers.stroke(d, chart, series); });
-                    }
-                });
+                // Remove
+                removed = chart._handleTransition(theseShapes.exit(), duration, chart, series)
+                    .attr("r", 0)
+                    .attr("cx", function (d) { return (series.x._hasCategories() ? dimple._helpers.cx(d, chart, series) : series.x._origin); })
+                    .attr("cy", function (d) { return (series.y._hasCategories() ? dimple._helpers.cy(d, chart, series) : series.y._origin); });
 
-            // Remove
-            removed = chart._handleTransition(theseShapes.exit(), duration, chart, series)
-                .attr("r", 0)
-                .attr("cx", function (d) { return (series.x._hasCategories() ? dimple._helpers.cx(d, chart, series) : series.x._origin); })
-                .attr("cy", function (d) { return (series.y._hasCategories() ? dimple._helpers.cy(d, chart, series) : series.y._origin); });
-
-            dimple._postDrawHandling(series, updated, removed, duration);
-
+                dimple._postDrawHandling(series, updated, removed, duration);
+            });
             // Save the shapes to the series array
             series.shapes = theseShapes;
         }

--- a/src/objects/plot/line.js
+++ b/src/objects/plot/line.js
@@ -17,6 +17,7 @@
             // Get the position data
             var data = series._positionData,
                 lineData = [],
+                addShapes = null,
                 theseShapes = null,
                 className = "dimple-series-" + chart.series.indexOf(series),
                 firstAgg = (series.x._hasCategories() || series.y._hasCategories() ? 0 : 1),
@@ -65,7 +66,6 @@
                         .y(function (d) { return (series.y._hasCategories() || !originProperty ? d.y : series.y[originProperty]); })
                         .interpolate(inter);
                 };
-
             // Handle the special interpolation handling for step
             interpolation =  (series.interpolation === "step" ? "step-after" : series.interpolation);
 
@@ -118,121 +118,136 @@
                     return dimple._arrayIndexCompare(orderedSeriesArray, a.key, b.key);
                 });
             }
-
-            // Create a set of line data grouped by the aggregation field
-            for (i = 0; i < lineData.length; i += 1) {
-                // Sort the points so that lines are connected in the correct order
-                lineData[i].data.sort(dimple._getSeriesSortPredicate(chart, series, orderedSeriesArray));
-                // If this should have colour gradients, add them
-                if (graded) {
-                    dimple._addGradient(lineData[i].key, "fill-line-gradient-" + lineData[i].keyString, (series.x._hasCategories() ? series.x : series.y), data, chart, duration, "fill");
-                }
-
-                // Get points here, this is so that as well as drawing the line with them, we can also
-                // use them for the baseline
-                for (j = 0; j < lineData[i].data.length; j += 1) {
-                    lineData[i].points.push({
-                        x: coord("x", lineData[i].data[j]),
-                        y: coord("y", lineData[i].data[j])
-                    });
-                }
-                // If this is a step interpolation we need to add in some extra points to the category axis
-                // This is a little tricky but we need to add a new point duplicating the last category value.  In order
-                // to place the point we need to calculate the gap between the last x and the penultimate x and apply that
-                // gap again.
-                if (series.interpolation === "step" && lineData[i].points.length > 1) {
-                    if (series.x._hasCategories()) {
-                        lineData[i].points.push({
-                            x : 2 * lineData[i].points[lineData[i].points.length - 1].x - lineData[i].points[lineData[i].points.length - 2].x,
-                            y : lineData[i].points[lineData[i].points.length - 1].y
-                        });
-                    } else if (series.y._hasCategories()) {
-                        lineData[i].points = [{
-                            x : lineData[i].points[0].x,
-                            y : 2 * lineData[i].points[0].y - lineData[i].points[1].y
-                        }].concat(lineData[i].points);
+            fastdom.read(function() {
+                for (i = 0; i < lineData.length; i += 1) {
+                    for (j = 0; j < lineData[i].data.length; j += 1) {
+                        dimple._helpers.buildCache(lineData[i].data[j], chart, series);
                     }
                 }
+            });
+            fastdom.write(function() {
+                // Create a set of line data grouped by the aggregation field
+                for (i = 0; i < lineData.length; i += 1) {
+                    // Sort the points so that lines are connected in the correct order
+                    lineData[i].data.sort(dimple._getSeriesSortPredicate(chart, series, orderedSeriesArray));
+                    // If this should have colour gradients, add them
+                    if (graded) {
+                        dimple._addGradient(lineData[i].key, "fill-line-gradient-" + lineData[i].keyString, (series.x._hasCategories() ? series.x : series.y), data, chart, duration, "fill");
+                    }
 
-                // Special case when a line contains a single point - duplicate the point
-                // If we don't do this a path will be created with 0,0 coordinates
-                if (lineData && lineData[i] && lineData[i].points &&  lineData[i].points.length === 1) {
-                    lineData[i].points.push(
-                        {
-                            x : lineData[i].points[0].x,
-                            y : lineData[i].points[0].y
+                    // Get points here, this is so that as well as drawing the line with them, we can also
+                    // use them for the baseline
+                    for (j = 0; j < lineData[i].data.length; j += 1) {
+                        lineData[i].points.push({
+                            x: coord("x", lineData[i].data[j]),
+                            y: coord("y", lineData[i].data[j])
+                        });
+                    }
+                    // If this is a step interpolation we need to add in some extra points to the category axis
+                    // This is a little tricky but we need to add a new point duplicating the last category value.  In order
+                    // to place the point we need to calculate the gap between the last x and the penultimate x and apply that
+                    // gap again.
+                    if (series.interpolation === "step" && lineData[i].points.length > 1) {
+                        if (series.x._hasCategories()) {
+                            lineData[i].points.push({
+                                x : 2 * lineData[i].points[lineData[i].points.length - 1].x - lineData[i].points[lineData[i].points.length - 2].x,
+                                y : lineData[i].points[lineData[i].points.length - 1].y
+                            });
+                        } else if (series.y._hasCategories()) {
+                            lineData[i].points = [{
+                                x : lineData[i].points[0].x,
+                                y : 2 * lineData[i].points[0].y - lineData[i].points[1].y
+                            }].concat(lineData[i].points);
                         }
-                    );
+                    }
+
+                    // Special case when a line contains a single point - duplicate the point
+                    // If we don't do this a path will be created with 0,0 coordinates
+                    if (lineData && lineData[i] && lineData[i].points &&  lineData[i].points.length === 1) {
+                        lineData[i].points.push(
+                            {
+                                x : lineData[i].points[0].x,
+                                y : lineData[i].points[0].y
+                            }
+                        );
+                    }
+
+                    // Get the points that this line will appear
+                    lineData[i].entry = getLine(interpolation, "_previousOrigin")(lineData[i].points);
+                    lineData[i].update = getLine(interpolation)(lineData[i].points);
+                    lineData[i].exit = getLine(interpolation, "_origin")(lineData[i].points);
+
+                    // Add the color in this loop, it can't be done during initialisation of the row because
+                    // the lines should be ordered first (to ensure standard distribution of colors
+                    lineData[i].color = chart.getColor(lineData[i].key.length > 0 ? lineData[i].key[lineData[i].key.length - 1] : "All");
+                    lineData[i].css = chart.getClass(lineData[i].key.length > 0 ? lineData[i].key[lineData[i].key.length - 1] : "All");
                 }
-
-                // Get the points that this line will appear
-                lineData[i].entry = getLine(interpolation, "_previousOrigin")(lineData[i].points);
-                lineData[i].update = getLine(interpolation)(lineData[i].points);
-                lineData[i].exit = getLine(interpolation, "_origin")(lineData[i].points);
-
-                // Add the color in this loop, it can't be done during initialisation of the row because
-                // the lines should be ordered first (to ensure standard distribution of colors
-                lineData[i].color = chart.getColor(lineData[i].key.length > 0 ? lineData[i].key[lineData[i].key.length - 1] : "All");
-                lineData[i].css = chart.getClass(lineData[i].key.length > 0 ? lineData[i].key[lineData[i].key.length - 1] : "All");
-            }
-
-            if (chart._tooltipGroup !== null && chart._tooltipGroup !== undefined) {
-                chart._tooltipGroup.remove();
-            }
-
+                if (chart._tooltipGroup !== null && chart._tooltipGroup !== undefined) {
+                    chart._tooltipGroup.remove();
+                }
+            });
             if (series.shapes === null || series.shapes === undefined) {
                 theseShapes = chart._group.selectAll("." + className).data(lineData);
             } else {
                 theseShapes = series.shapes.data(lineData, function (d) { return d.key; });
             }
 
-            // Add
-            theseShapes
-                .enter()
-                .append("path")
-                .attr("id", function (d) { return dimple._createClass([d.key]); })
-                .attr("class", function (d) {
-                    return className + " dimple-line " + d.keyString + " " + chart.customClassList.lineSeries + " " + d.css;
-                })
-                .attr("d", function (d) {
-                    return d.entry;
-                })
-                .call(function () {
-                    // Apply formats optionally
-                    if (!chart.noFormats) {
-                        this.attr("opacity", function (d) { return (graded ? 1 : d.color.opacity); })
-                            .style("fill", "none")
-                            .style("stroke", function (d) { return (graded ? "url(#" + dimple._createClass(["fill-line-gradient-" + d.keyString]) + ")" : d.color.stroke); })
-                            .style("stroke-width", series.lineWeight);
-                    }
-                })
-                .each(function (d) {
-                    // Pass line data to markers
-                    d.markerData = d.data;
-                    drawMarkers(d, this);
-                });
+            fastdom.read(function() {
+                addShapes = theseShapes
+                    .enter()
+                    .append("path")
+                    .each(function(d) {
+                        dimple._helpers.buildCache(d, chart, series);
+                    });
+            });
 
-            // Update
-            updated = chart._handleTransition(theseShapes, duration, chart)
-                .attr("d", function (d) { return d.update; })
-                .each(function (d) {
-                    // Pass line data to markers
-                    d.markerData = d.data;
-                    drawMarkers(d, this);
-                });
 
-            // Remove
-            removed = chart._handleTransition(theseShapes.exit(), duration, chart)
-                .attr("d", function (d) { return d.exit; })
-                .each(function (d) {
-                    // Using all data for the markers fails because there are no exits in the markers
-                    // only the whole line, therefore we need to clear the points here
-                    d.markerData = [];
-                    drawMarkers(d, this);
-                });
+            fastdom.write(function() {
+                // Add
+                addShapes
+                    .attr("id", function (d) { return dimple._createClass([d.key]); })
+                    .attr("class", function (d) {
+                        return className + " dimple-line " + d.keyString + " " + chart.customClassList.lineSeries + " " + d.css;
+                    })
+                    .attr("d", function (d) {
+                        return d.entry;
+                    })
+                    .call(function () {
+                        // Apply formats optionally
+                        if (!chart.noFormats) {
+                            this.attr("opacity", function (d) { return (graded ? 1 : d.color.opacity); })
+                                .style("fill", "none")
+                                .style("stroke", function (d) { return (graded ? "url(#" + dimple._createClass(["fill-line-gradient-" + d.keyString]) + ")" : d.color.stroke); })
+                                .style("stroke-width", series.lineWeight);
+                        }
+                    })
+                    .each(function (d) {
+                        // Pass line data to markers
+                        d.markerData = d.data;
+                        drawMarkers(d, this);
+                    });
 
-            dimple._postDrawHandling(series, updated, removed, duration);
+                // Update
+                updated = chart._handleTransition(theseShapes, duration, chart)
+                    .attr("d", function (d) { return d.update; })
+                    .each(function (d) {
+                        // Pass line data to markers
+                        d.markerData = d.data;
+                        drawMarkers(d, this);
+                    });
 
+                // Remove
+                removed = chart._handleTransition(theseShapes.exit(), duration, chart)
+                    .attr("d", function (d) { return d.exit; })
+                    .each(function (d) {
+                        // Using all data for the markers fails because there are no exits in the markers
+                        // only the whole line, therefore we need to clear the points here
+                        d.markerData = [];
+                        drawMarkers(d, this);
+                    });
+
+                dimple._postDrawHandling(series, updated, removed, duration);
+            });
             // Save the shapes to the series array
             series.shapes = theseShapes;
 

--- a/src/objects/series/begin.js
+++ b/src/objects/series/begin.js
@@ -49,3 +49,21 @@
         this._positionData = [];
         // The order definition array
         this._orderRules = [];
+
+        // DOM Cache
+        this.domCache = {
+            cx: [],
+            cy: [],
+            r: [],
+            xGap: null,
+            xClusterGap: [],
+            yGap: null,
+            yClusterGap: [],
+            x: [],
+            y: [],
+            width: [],
+            height: [],
+            opacity: [],
+            fill: [],
+            stroke: []
+        };


### PR DESCRIPTION
Avoid force relayouts for better performance. See https://github.com/PMSI-AlignAlytics/dimple/issues/178 for more details.

All codepaths that access _helpers should now be surrounded in fastdom.

Some known issues:
- Line & Area charts encounter an undefined when calling into getMarkers
- Area charts render very incorrectly
- Pie charts aren't showing legends (may be unrelated)

Testing across all main chart types has been completed, but more thorough testing is needed.
